### PR TITLE
Change Http4s version to 0.23.0-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ addCommandAlias("validate", ";fmtCheck; test; it:compile")
 
 val CirceVersion = "0.14.0-M5"
 val Fs2Version = "3.0.4"
-val Http4sVersion = "0.23.0-RC1"
+val Http4sVersion = "0.23.1"
 val ScalatestVersion = "3.1.0"
 
 lazy val commonSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -53,7 +53,7 @@ addCommandAlias("validate", ";fmtCheck; test; it:compile")
 
 val CirceVersion = "0.14.0-M5"
 val Fs2Version = "3.0.4"
-val Http4sVersion = "1.0.0-M21"
+val Http4sVersion = "0.23.0-RC1"
 val ScalatestVersion = "3.1.0"
 
 lazy val commonSettings = Seq(

--- a/migrate/src/it/scala/compstak/http4s/kafka/connect/MigrationSpec.scala
+++ b/migrate/src/it/scala/compstak/http4s/kafka/connect/MigrationSpec.scala
@@ -1,16 +1,15 @@
 package compstak.http4s.kafka.connect
 
-import scala.concurrent.ExecutionContext
-import scala.concurrent.duration._
-
 import cats.effect._
 import cats.effect.unsafe.implicits.global
 import cats.implicits._
 import io.circe.literal._
 import org.http4s.Uri
-import org.http4s.client.asynchttpclient.AsyncHttpClient
+import org.http4s.asynchttpclient.client.AsyncHttpClient
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration._
 
 class MigrationSpec extends AnyFunSuite with Matchers {
 


### PR DESCRIPTION
http4s to version 0.23.0-RC1.

Reasoning behind that change:
- 0.23.0-RC1 is close to having a stable version released
- Using ce3 as well
- more stable than current 1.* branch as it is currently still actively developed.

If this can be merged, could you also release those changes? There is a separate PR for kafka-streams-4s which bumps to ce3, but as this lib is a dependency, the migration cannot be completed until a ce3 compatible version of this lib is released.